### PR TITLE
Updated to 2.x POM to be able to deploy a release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609.1</version>
+    <version>2.19</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/database/Main.java
+++ b/src/test/java/org/jenkinsci/plugins/database/Main.java
@@ -1,9 +1,12 @@
 package org.jenkinsci.plugins.database;
 
+import org.apache.mina.transport.socket.nio.NioSocketConnector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ServerConnector;
 import org.jvnet.hudson.test.HudsonHomeLoader;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.kohsuke.stapler.MetaClass;
-import org.mortbay.jetty.bio.SocketConnector;
 
 import java.io.File;
 
@@ -26,9 +29,12 @@ public class Main extends HudsonTestCase {
     }
 
     public void test1() throws Exception {
-        SocketConnector connector = new SocketConnector();
+        ServerConnector connector = new ServerConnector(server);
         connector.setPort(localPort=8888);
-        connector.setHeaderBufferSize(12 * 1024); // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
+        HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
+        // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
+        config.setRequestHeaderSize(12 * 1024);
+
         server.addConnector(connector);
         connector.start();
 


### PR DESCRIPTION
This change updates POM to 2.x so that we can cut a new release (or deploy a snapshot, which is what made me realize this change is needed)