### PR TITLE
Expose connection pool size to generic database

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/database/GenericDatabase.java
+++ b/src/main/java/org/jenkinsci/plugins/database/GenericDatabase.java
@@ -24,15 +24,24 @@ public class GenericDatabase extends Database {
     public final String username;
     public final Secret password;
     public final String url;
+    public final int initialSize;
+    public final int maxTotal;
+    public final int maxIdle;
+    public final int minIdle;
 
     private transient DataSource source;
 
     @DataBoundConstructor
-    public GenericDatabase(String url, String driver, String username, Secret password) {
+    public GenericDatabase(String url, String driver, String username, Secret password,
+                           int initialSize, int maxTotal, int maxIdle, int minIdle) {
         this.url = url;
         this.driver = driver;
         this.username = username;
         this.password = password;
+        this.initialSize = initialSize;
+        this.maxTotal = maxTotal;
+        this.maxIdle = maxIdle;
+        this.minIdle = minIdle;
     }
 
     @Override
@@ -44,6 +53,10 @@ public class GenericDatabase extends Database {
             source.setUrl(url);
             source.setUsername(username);
             source.setPassword(Secret.toString(password));
+            source.setInitialSize(initialSize);
+            source.setMaxTotal(maxTotal);
+            source.setMaxIdle(maxIdle);
+            source.setMinIdle(minIdle);
             this.source = source.createDataSource();
         }
         return source;
@@ -102,11 +115,15 @@ public class GenericDatabase extends Database {
         public FormValidation doValidate(@QueryParameter String driver,
                                          @QueryParameter String url,
                                          @QueryParameter String username,
-                                         @QueryParameter Secret password) {
+                                         @QueryParameter Secret password,
+                                         @QueryParameter int initialSize,
+                                         @QueryParameter int maxTotal,
+                                         @QueryParameter int maxIdle,
+                                         @QueryParameter int minIdle) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             
             try {
-                new GenericDatabase(url,driver,username, password).getDataSource();
+                new GenericDatabase(url,driver,username, password, initialSize, maxTotal, maxIdle, minIdle).getDataSource();
                 // XXX what about the "SELECT 1" trick from AbstractRemoteDatabaseDescriptor?
                 return FormValidation.ok("OK");
             } catch (SQLException e) {

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
@@ -29,5 +29,5 @@ f.advanced {
     }
 }
 f.block() {
-    f.validateButton(method:"validate",title:_("Test Connection"),with:"driver,url,username,password,maxTotal")
+    f.validateButton(method:"validate",title:_("Test Connection"),with:"driver,url,username,password")
 }

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.database.GenericDatabase
 
 def f = namespace(lib.FormTagLib)
 
-f.entry(field:"driver",title:_("JDBC Driver Class")) {
+f.entry(field:"driver",title:_("JDBC Driver Class"), help: descriptor.getHelpFile('driver')) {
     f.textbox()
 }
 f.entry(field:"url",title:_("JDBC Connection URL")) {
@@ -14,6 +14,20 @@ f.entry(field:"username",title:_("User Name")) {
 f.entry(field:"password",title:_("Password")) {
     f.password()
 }
+f.advanced {
+    f.entry(field: "initialSize", title: _("Initial Size"), help: descriptor.getHelpFile('initialSize')) {
+        f.number(clazz: "number", min: 0, max: 65535, step: 1, default: 0)
+    }
+    f.entry(field: "maxTotal", title: _("Max Total"), help: descriptor.getHelpFile('maxTotal')) {
+        f.number(clazz: "number", min: -1, max: 65535, step: 1, default: 8)
+    }
+    f.entry(field: "minIdle", title: _("Min Idle"), help: descriptor.getHelpFile('minIdle')) {
+        f.number(clazz: "number", min: 0, max: 65535, step: 1, default: 0)
+    }
+    f.entry(field: "maxIdle", title: _("Max Idle"), help: descriptor.getHelpFile('maxIdle')) {
+        f.number(clazz: "number", min: -1, max: 65535, step: 1, default: 8)
+    }
+}
 f.block() {
-    f.validateButton(method:"validate",title:_("Test Connection"),with:"driver,url,username,password")
+    f.validateButton(method:"validate",title:_("Test Connection"),with:"driver,url,username,password,maxTotal")
 }

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.database.GenericDatabase
 
 def f = namespace(lib.FormTagLib)
 
-f.entry(field:"driver",title:_("JDBC Driver Class"), help: descriptor.getHelpFile('driver')) {
+f.entry(field:"driver",title:_("JDBC Driver Class")) {
     f.textbox()
 }
 f.entry(field:"url",title:_("JDBC Connection URL")) {
@@ -15,16 +15,16 @@ f.entry(field:"password",title:_("Password")) {
     f.password()
 }
 f.advanced {
-    f.entry(field: "initialSize", title: _("Initial Size"), help: descriptor.getHelpFile('initialSize')) {
+    f.entry(field: "initialSize", title: _("Initial Size")) {
         f.number(clazz: "number", min: 0, max: 65535, step: 1, default: "${descriptor.defaultInitialSize}")
     }
-    f.entry(field: "maxTotal", title: _("Max Total"), help: descriptor.getHelpFile('maxTotal')) {
+    f.entry(field: "maxTotal", title: _("Max Total")) {
         f.number(clazz: "number", min: -1, max: 65535, step: 1, default: "${descriptor.defaultMaxTotal}")
     }
-    f.entry(field: "maxIdle", title: _("Max Idle"), help: descriptor.getHelpFile('maxIdle')) {
+    f.entry(field: "maxIdle", title: _("Max Idle")) {
         f.number(clazz: "number", min: -1, max: 65535, step: 1, default: "${descriptor.defaultMaxIdle}")
     }
-    f.entry(field: "minIdle", title: _("Min Idle"), help: descriptor.getHelpFile('minIdle')) {
+    f.entry(field: "minIdle", title: _("Min Idle")) {
         f.number(clazz: "number", min: 0, max: 65535, step: 1, default: "${descriptor.defaultMinIdle}")
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/config.groovy
@@ -16,16 +16,16 @@ f.entry(field:"password",title:_("Password")) {
 }
 f.advanced {
     f.entry(field: "initialSize", title: _("Initial Size"), help: descriptor.getHelpFile('initialSize')) {
-        f.number(clazz: "number", min: 0, max: 65535, step: 1, default: 0)
+        f.number(clazz: "number", min: 0, max: 65535, step: 1, default: "${descriptor.defaultInitialSize}")
     }
     f.entry(field: "maxTotal", title: _("Max Total"), help: descriptor.getHelpFile('maxTotal')) {
-        f.number(clazz: "number", min: -1, max: 65535, step: 1, default: 8)
-    }
-    f.entry(field: "minIdle", title: _("Min Idle"), help: descriptor.getHelpFile('minIdle')) {
-        f.number(clazz: "number", min: 0, max: 65535, step: 1, default: 0)
+        f.number(clazz: "number", min: -1, max: 65535, step: 1, default: "${descriptor.defaultMaxTotal}")
     }
     f.entry(field: "maxIdle", title: _("Max Idle"), help: descriptor.getHelpFile('maxIdle')) {
-        f.number(clazz: "number", min: -1, max: 65535, step: 1, default: 8)
+        f.number(clazz: "number", min: -1, max: 65535, step: 1, default: "${descriptor.defaultMaxIdle}")
+    }
+    f.entry(field: "minIdle", title: _("Min Idle"), help: descriptor.getHelpFile('minIdle')) {
+        f.number(clazz: "number", min: 0, max: 65535, step: 1, default: "${descriptor.defaultMinIdle}")
     }
 }
 f.block() {

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-initialSize.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-initialSize.html
@@ -1,0 +1,3 @@
+<div>
+    The initial number of connections that are created when the pool is started.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-maxIdle.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-maxIdle.html
@@ -1,0 +1,3 @@
+<div>
+    The maximum number of connections that can remain idle in the pool, without extra ones being released, or negative for no limit.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-maxTotal.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-maxTotal.html
@@ -1,0 +1,3 @@
+<div>
+    The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-minIdle.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/GenericDatabase/help-minIdle.html
@@ -1,0 +1,3 @@
+<div>
+    The minimum number of connections that can remain idle in the pool, without extra ones being created, or zero to create none.
+</div>


### PR DESCRIPTION
[JENKINS-65527]
Exposed connection pool size properties in an advanced section.
Initial Size, Max Total, Min Idle and Max Idle all provided with defaults as per commons dbcp.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
