### PR TITLE
Use JAXB plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/database-plugin</gitHubRepo>
-    <jenkins.version>2.249.1</jenkins.version>
+    <jenkins.version>2.263.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
   
@@ -24,8 +24,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
-        <version>961.vf0c9f6f59827</version>
+        <artifactId>bom-2.263.x</artifactId>
+        <version>984.vb5eaac999a7e</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -48,7 +48,34 @@
           <groupId>antlr</groupId>
           <artifactId>antlr</artifactId>
         </exclusion>
+        <!-- Provided by javax-activation-api plugin -->
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+        <!-- Provided by jaxb plugin -->
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+        <!-- Provided by jaxb plugin -->
+        <exclusion>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>javax-activation-api</artifactId>
+      <version>1.2.0-3</version> <!-- TODO use version from BOM when possible -->
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>2.3.6-1</version> <!-- TODO use version from BOM when possible -->
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Like https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/280 and https://github.com/jenkinsci/jackson2-api-plugin/pull/139. Use the JAXB API from the JAXB plugin, relying on dynamic linking through a plugin-to-plugin dependency rather than embedding the JAXB API JAR file unnecessarily in this plugin's `.jpi`. CC @timja