### PR TITLE
Bundle antlr as core no longer provides it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/database-plugin</gitHubRepo>
-    <!-- TODO https://github.com/jenkinsci/jenkins/pull/7293 -->
-    <jenkins.version>2.376-rc33064.84d8e35b_0996</jenkins.version>
+    <jenkins.version>2.376</jenkins.version>
   </properties>
   
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,15 +16,16 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/database-plugin</gitHubRepo>
-    <jenkins.version>2.263.1</jenkins.version>
+    <!-- TODO https://github.com/jenkinsci/jenkins/pull/7293 -->
+    <jenkins.version>2.376-rc33064.84d8e35b_0996</jenkins.version>
   </properties>
   
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.263.x</artifactId>
-        <version>984.vb5eaac999a7e</version>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>1654.vcb_69d035fa_20</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -43,10 +44,6 @@
       <artifactId>hibernate-entitymanager</artifactId>
       <version>5.6.12.Final</version>
       <exclusions>
-        <exclusion>
-          <groupId>antlr</groupId>
-          <artifactId>antlr</artifactId>
-        </exclusion>
         <!-- Provided by javax-activation-api plugin -->
         <exclusion>
           <groupId>javax.activation</groupId>
@@ -68,13 +65,11 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>javax-activation-api</artifactId>
-      <version>1.2.0-3</version> <!-- TODO use version from BOM when possible -->
     </dependency>
 
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jaxb</artifactId>
-      <version>2.3.6-1</version> <!-- TODO use version from BOM when possible -->
     </dependency>
 
     <dependency>
@@ -115,7 +110,7 @@
   </pluginRepositories>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>


### PR DESCRIPTION
This plugin consumes ANTLR 2 transitively, and excludes the JAR under the assumption that it is bundled in core. That assumption is no longer true as of https://github.com/jenkinsci/jenkins/pull/7293, so this PR updates the baseline and removes the exclusion accordingly. I couldn't think of a way to prepare this plugin in advance, since if I just excluded the dependency while keeping the core baseline at its original value then Maven HPI plugin wouldn't bundle the JAR. But with this PR I confirmed the JAR does get bundled:

```
[WARNING] Bundling transitive dependency antlr-2.7.7.jar (via hibernate-entitymanager)
```

I am planning on merging https://github.com/jenkinsci/jenkins/pull/7293 tomorrow toward 2.376, so this would need to be updated to the final released version and released at the same time. CC @timja